### PR TITLE
Fix typo in variable name in CustomPalette and CustomContextPad

### DIFF
--- a/app/custom/CustomContextPad.js
+++ b/app/custom/CustomContextPad.js
@@ -1,5 +1,5 @@
 const SUITABILITY_SCORE_HIGH = 100,
-      SUITABILITY_SCORE_AVERGE = 50,
+      SUITABILITY_SCORE_AVERAGE = 50,
       SUITABILITY_SCORE_LOW = 25;
 
 export default class CustomContextPad {
@@ -74,8 +74,8 @@ export default class CustomContextPad {
         className: 'bpmn-icon-task yellow',
         title: translate('Append Task with average suitability score'),
         action: {
-          click: appendServiceTask(SUITABILITY_SCORE_AVERGE),
-          dragstart: appendServiceTaskStart(SUITABILITY_SCORE_AVERGE)
+          click: appendServiceTask(SUITABILITY_SCORE_AVERAGE),
+          dragstart: appendServiceTaskStart(SUITABILITY_SCORE_AVERAGE)
         }
       },
       'append.high-task': {

--- a/app/custom/CustomPalette.js
+++ b/app/custom/CustomPalette.js
@@ -1,5 +1,5 @@
 const SUITABILITY_SCORE_HIGH = 100,
-      SUITABILITY_SCORE_AVERGE = 50,
+      SUITABILITY_SCORE_AVERAGE = 50,
       SUITABILITY_SCORE_LOW = 25;
 
 export default class CustomPalette {
@@ -50,8 +50,8 @@ export default class CustomPalette {
         className: 'bpmn-icon-task yellow',
         title: translate('Create Task with average suitability score'),
         action: {
-          dragstart: createTask(SUITABILITY_SCORE_AVERGE),
-          click: createTask(SUITABILITY_SCORE_AVERGE)
+          dragstart: createTask(SUITABILITY_SCORE_AVERAGE),
+          click: createTask(SUITABILITY_SCORE_AVERAGE)
         }
       },
       'create.high-task': {


### PR DESCRIPTION
### Proposed Changes

Fix **typo** in variable name `SUITABILITY_SCORE_AVERAGE` in `CustomPalette` and `CustomContextPad` files. Previously one letter in `AVERAGE` was missing.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
